### PR TITLE
cut segments multiple times in nb5

### DIFF
--- a/notebooks/5. Compute sidewalk width.ipynb
+++ b/notebooks/5. Compute sidewalk width.ipynb
@@ -136,15 +136,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_points_on_line(line, max_seg_length): \n",
-    "    distance_delta = max_seg_length   \n",
-    "    # generate the equidistant points\n",
+    "def get_points_on_line(line, distance_delta):  \n",
+    "    # Generate equidistant points\n",
     "    distances = np.arange(0, line.length, distance_delta)\n",
-    "    points = sg.MultiPoint([line.interpolate(distance) for distance in distances] + [(line.coords[0], line.coords[-2])])\n",
+    "    points = sg.MultiPoint([line.interpolate(distance) for distance in distances])\n",
     "    return points\n",
     "\n",
-    "def split_line_by_point(line, point, tolerance: float=0.001): \n",
-    "    return so.split(so.snap(line, point, tolerance), point)"
+    "def split_line_by_points(line, points, tolerance: float=0.001):\n",
+    "    return so.split(so.snap(line, points, tolerance), points)"
    ]
   },
   {
@@ -169,7 +168,7 @@
     "    segments = []\n",
     "    for seg in segments_long:\n",
     "        points_on_line = get_points_on_line(seg, max_seg_length)\n",
-    "        seg_cut = split_line_by_point(seg, points_on_line)\n",
+    "        seg_cut = split_line_by_points(seg, points_on_line)\n",
     "        segments.extend(seg_cut)\n",
     "    # Compute avg and min width per cut segment   \n",
     "    avg_width, min_width = poly_utils.get_avg_width(\n",
@@ -250,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21e619ec",
+   "id": "b17d659a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,9 +305,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
+    "#%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
     "\n",
     "tilecodes = all_tiles\n",
     "\n",

--- a/notebooks/5. Compute sidewalk width.ipynb
+++ b/notebooks/5. Compute sidewalk width.ipynb
@@ -28,6 +28,7 @@
     "from tqdm.notebook import tqdm_notebook\n",
     "tqdm_notebook.pandas()\n",
     "import shapely.ops as so\n",
+    "import shapely.geometry as sg\n",
     "\n",
     "import upcp.utils.bgt_utils as bgt_utils\n",
     "import upcp.utils.las_utils as las_utils\n",
@@ -60,8 +61,8 @@
     "# Save intermediate output in case of errors\n",
     "tmp_file = f'{out_folder}sw_seg_tmp.pkl'\n",
     "\n",
-    "# A CRS tells Python how those coordinates relate to places on the Earth. Rijksdriehoek = epsg:28992\n",
-    "CRS = 'epsg:28992' #local crs\n",
+    "# Set Coordinate Reference System\n",
+    "CRS = 'epsg:28992' \n",
     "\n",
     "# Whether to merge sidewalks before segmentation and width computation\n",
     "merge_sidewalks = True\n",
@@ -76,7 +77,7 @@
     "min_se_length = 5\n",
     "\n",
     "# Max segment length in meters\n",
-    "max_seg_length = 5 \n",
+    "max_seg_length = 2 \n",
     "\n",
     "# Resolution (in m) for min and avg width computation\n",
     "width_resolution = 1\n",
@@ -131,7 +132,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb577bc3",
+   "id": "b3d9e7fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_points_on_line(line, max_seg_length): \n",
+    "    distance_delta = max_seg_length   \n",
+    "    # generate the equidistant points\n",
+    "    distances = np.arange(0, line.length, distance_delta)\n",
+    "    points = sg.MultiPoint([line.interpolate(distance) for distance in distances] + [(line.coords[0], line.coords[-2])])\n",
+    "    return points\n",
+    "\n",
+    "def split_line_by_point(line, point, tolerance: float=0.001): \n",
+    "    return so.split(so.snap(line, point, tolerance), point)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "892ba063",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +168,8 @@
     "    # Cut segments (with maximum segment length)\n",
     "    segments = []\n",
     "    for seg in segments_long:\n",
-    "        seg_cut = poly_utils.cut(seg, max_seg_length)\n",
+    "        points_on_line = get_points_on_line(seg, max_seg_length)\n",
+    "        seg_cut = split_line_by_point(seg, points_on_line)\n",
     "        segments.extend(seg_cut)\n",
     "    # Compute avg and min width per cut segment   \n",
     "    avg_width, min_width = poly_utils.get_avg_width(\n",
@@ -166,7 +186,9 @@
    "outputs": [],
    "source": [
     "# if you get an error here, make sure you use tqdm>=4.61.2\n",
-    "segment_df = pd.DataFrame(df.progress_apply(get_segments_width_cut, max_seg_length=max_seg_length, axis=1).values.tolist())\n",
+    "segment_df = pd.DataFrame(df.progress_apply(get_segments_width_cut, \n",
+    "                                            max_seg_length=max_seg_length,                                                     \n",
+    "                                            axis=1).values.tolist())\n",
     "\n",
     "with open(tmp_file, 'wb') as f:\n",
     "    pickle.dump(segment_df.to_dict(), f)"
@@ -228,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8352e386",
+   "id": "21e619ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,9 +331,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sidewalk",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "sidewalk"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -323,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed a few lines of code in notebook 5, to make sure all segments are cut multiple times, to have pieces of max 2 meters. This reduces the amount of unknown obstacle-free widths (in notebook 6, by reducing 'node too far').